### PR TITLE
Added bettercap 2.27.1.  Does not automatically install default caplets.

### DIFF
--- a/network/bettercap/Makefile
+++ b/network/bettercap/Makefile
@@ -13,7 +13,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=LICENSE.md
-PKG_MAINTAINER:=Simone Margaritelli <evilsocket@evilsocket.net>
+PKG_MAINTAINER:=Benjamin Kurtz <awgh@awgh.org>
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1

--- a/network/bettercap/Makefile
+++ b/network/bettercap/Makefile
@@ -1,0 +1,54 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bettercap
+PKG_VERSION:=2.27.1
+PKG_RELEASE:=1
+
+GO_PKG:=github.com/bettercap/bettercap
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/bettercap/bettercap/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=dd4349a43486ec300a0f777f7c53b2fff608fb82dbba720c144b85538811405c
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=LICENSE.md
+PKG_MAINTAINER:=Simone Margaritelli <evilsocket@evilsocket.net>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/bettercap/Default
+  TITLE:=The Swiss Army knife for 802.11, BLE and Ethernet networks reconnaissance and MITM attacks.
+  URL:=https://www.bettercap.org/
+  DEPENDS:=$(GO_ARCH_DEPENDS) libpcap libusb-1.0
+endef
+
+define Package/bettercap
+$(call Package/bettercap/Default)
+  SECTION:=net
+  CATEGORY:=Network
+endef
+
+define Package/bettercap/description
+bettercap is a powerful, easily extensible and portable framework written 
+in Go which aims to offer to security researchers, red teamers and reverse 
+engineers an easy to use, all-in-one solution with all the features they 
+might possibly need for performing reconnaissance and attacking WiFi 
+networks, Bluetooth Low Energy devices, wireless HID devices and Ethernet networks.
+endef
+
+define Package/bettercap/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/bettercap  $(1)/usr/bin/bettercap
+endef
+
+$(eval $(call GoBinPackage,bettercap))
+$(eval $(call BuildPackage,bettercap))
+
+


### PR DESCRIPTION

Tested on a Nano.  It requires an SD card with swap set up.  Due to the binary size, you'd most likely want to install to SD also.

The normal bettercap installation installs the caplet scripts to /usr/local/share/bettercap, however these scripts are optional and live in a different git repo than bettercap, so can be fetched easily outside of the package installation if needed.